### PR TITLE
loginのAPIを叩く処理を実装しました

### DIFF
--- a/KrononIosNakane.xcodeproj/project.pbxproj
+++ b/KrononIosNakane.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4F49139F26138F9E008B7D26 /* AlertDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F49139E26138F9E008B7D26 /* AlertDialog.swift */; };
+		4F4913A22613A2CD008B7D26 /* CommonData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4913A12613A2CD008B7D26 /* CommonData.swift */; };
 		4F70272125F69F05001002F6 /* UIButton+ibinspectable.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F70272025F69F05001002F6 /* UIButton+ibinspectable.swift.swift */; };
 		4F70272425F6A2CB001002F6 /* MyTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F70272325F6A2CB001002F6 /* MyTextField.swift */; };
 		4F70272A25F84051001002F6 /* CreateAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F70272925F84051001002F6 /* CreateAccountViewController.swift */; };
@@ -28,6 +30,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4F49139E26138F9E008B7D26 /* AlertDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDialog.swift; sourceTree = "<group>"; };
+		4F4913A12613A2CD008B7D26 /* CommonData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonData.swift; sourceTree = "<group>"; };
 		4F70272025F69F05001002F6 /* UIButton+ibinspectable.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+ibinspectable.swift.swift"; sourceTree = "<group>"; };
 		4F70272325F6A2CB001002F6 /* MyTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTextField.swift; sourceTree = "<group>"; };
 		4F70272925F84051001002F6 /* CreateAccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccountViewController.swift; sourceTree = "<group>"; };
@@ -83,6 +87,8 @@
 				4FDFAA9C25E399A2007AD04B /* AppDelegate.swift */,
 				4FDFAA9E25E399A2007AD04B /* SceneDelegate.swift */,
 				4FDFAAA025E399A2007AD04B /* ViewController.swift */,
+				4F49139E26138F9E008B7D26 /* AlertDialog.swift */,
+				4F4913A12613A2CD008B7D26 /* CommonData.swift */,
 				4FDFAAA225E399A2007AD04B /* Main.storyboard */,
 				4FB9790125FFB006007B2F3F /* CalendarViewController.swift */,
 				4F9E27F62610FA9500ABD699 /* CalendarCollectionViewCell.swift */,
@@ -177,6 +183,7 @@
 				4FDFAAA125E399A2007AD04B /* ViewController.swift in Sources */,
 				4F70272125F69F05001002F6 /* UIButton+ibinspectable.swift.swift in Sources */,
 				4F70272425F6A2CB001002F6 /* MyTextField.swift in Sources */,
+				4F49139F26138F9E008B7D26 /* AlertDialog.swift in Sources */,
 				4F70272A25F84051001002F6 /* CreateAccountViewController.swift in Sources */,
 				4FB9790525FFB013007B2F3F /* ScheduleViewController.swift in Sources */,
 				4FDFAA9D25E399A2007AD04B /* AppDelegate.swift in Sources */,
@@ -185,6 +192,7 @@
 				4F9E27F72610FA9500ABD699 /* CalendarCollectionViewCell.swift in Sources */,
 				4FDFAADA25E8DBBF007AD04B /* UIView+ibinspectable.swift in Sources */,
 				4FDFAA9F25E399A2007AD04B /* SceneDelegate.swift in Sources */,
+				4F4913A22613A2CD008B7D26 /* CommonData.swift in Sources */,
 				4FB9790825FFB020007B2F3F /* AccountViewController.swift in Sources */,
 				4F9E27EE261057E300ABD699 /* CustomDatePicker.swift in Sources */,
 				4FB9790F26001B59007B2F3F /* UITextView+ibinspectable.swift in Sources */,

--- a/KrononIosNakane/AlertDialog.swift
+++ b/KrononIosNakane/AlertDialog.swift
@@ -1,0 +1,22 @@
+//
+//  AlertDialog.swift
+//  KrononIosNakane
+//
+//  Created by 中根悠 on 2021/03/31.
+//
+
+import Foundation
+import UIKit
+
+//参考：https://qiita.com/funacchi/items/b76e62eb82fc8d788da5
+
+class AlertDialog{
+    public static func alert(viewController:UIViewController, title:String, message:String){
+        //アラートのタイトル
+        let dialog = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        //ボタンのタイトル
+        dialog.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        //実際に表示させる
+        viewController.present(dialog, animated: true, completion: nil)
+    }
+}

--- a/KrononIosNakane/Base.lproj/Main.storyboard
+++ b/KrononIosNakane/Base.lproj/Main.storyboard
@@ -461,7 +461,7 @@
             <objects>
                 <viewController id="Uoz-2X-VpG" customClass="CalendarViewController" customModule="KrononIosNakane" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="6O5-hz-7IJ">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="eCx-xy-WW3">

--- a/KrononIosNakane/CalendarViewController.swift
+++ b/KrononIosNakane/CalendarViewController.swift
@@ -53,6 +53,11 @@ class CalendarViewController: UIViewController, UICollectionViewDelegateFlowLayo
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        //テスト
+        let a = UserDefaults.standard.string(forKey: "email")
+        print(String(a!))
+        print("aaa")
+        
         //calendarCollectionView.dataSource = self
         //calendarCollectionView.register(UINib(nibName: "CalendarCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "CalendarCollectionViewCell")
         let date = Date()

--- a/KrononIosNakane/CommonData.swift
+++ b/KrononIosNakane/CommonData.swift
@@ -1,0 +1,12 @@
+//
+//  CommonData.swift
+//  KrononIosNakane
+//
+//  Created by 中根悠 on 2021/03/31.
+//
+
+import Foundation
+
+class CommonData{
+    static let IP_ADDRESS = "http://52.197.190.20/"
+}

--- a/KrononIosNakane/Info.plist
+++ b/KrononIosNakane/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string></string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -20,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -46,9 +50,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
+	<array/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/KrononIosNakane/LoginViewController.swift
+++ b/KrononIosNakane/LoginViewController.swift
@@ -111,7 +111,10 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
                         let jsonData = try JSONSerialization.data(withJSONObject: jsonDict!["data"]!, options: .prettyPrinted)
                         
                         if let loginData = try? JSONDecoder().decode(LoginData.self, from: jsonData as Data) {
-                            print(loginData.email)
+                            UserDefaults.standard.set(loginData.email, forKey:"email")
+                            UserDefaults.standard.set(loginData.name, forKey:"name")
+                            UserDefaults.standard.set(loginData.token, forKey:"token")
+                            //print(loginData.email)
                         }
                     }
                     

--- a/KrononIosNakane/LoginViewController.swift
+++ b/KrononIosNakane/LoginViewController.swift
@@ -7,10 +7,17 @@
 
 import UIKit
 
+
 class LoginViewController: UIViewController, UITextFieldDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        //キーボードのデフォルトを設定したいのに変わらないよ
+        inputEmail.keyboardType = .emailAddress
+        inputPassword.keyboardType = .emailAddress
+        //入力内容を隠す
+        inputPassword.isSecureTextEntry = true
         
         inputEmail.delegate = self
         inputPassword.delegate = self
@@ -25,7 +32,15 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var loginButton: UIButton!
     
     @IBAction func loginAction(_ sender: Any) {
-        self.performSegue(withIdentifier: "goTabBar", sender: nil)
+        let email = inputEmail.text!
+        let password = inputPassword.text!
+        if(email.isEmpty || password.isEmpty ){
+            AlertDialog.alert(viewController:self, title:"入力エラー", message:"未入力の項目があるよ。")
+            return
+        }
+        login(email: email, password: password)
+        
+        //self.performSegue(withIdentifier: "goTabBar", sender: nil)
     }
     
     @IBAction func createAccountAction(_ sender: Any) {
@@ -40,19 +55,132 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         return true
     }
     
-    //private, protected, publicは意識しょう
-    private func viewSetUp(){
+    
+    private func login(email:String, password:String){
+        guard let reqestUrl = URL(string: CommonData.IP_ADDRESS+"api/login") else{
+            return
+        }
         
+        let authString = String(format: "%@:%@", email, password)
+        let authData = authString.data(using: String.Encoding.utf8)!
+        let authBase64 = authData.base64EncodedString()
+        
+        let data: [String: Any] = ["email": email, "password": password]
+        guard let httpBody = try? JSONSerialization.data(withJSONObject: data, options: []) else { return }
+        
+        //リクエストに必要な情報を生成
+        var request = URLRequest(url: reqestUrl)
+        request.httpMethod = "POST"
+        
+        request.setValue("Application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Basic \(authBase64)", forHTTPHeaderField: "Authorization")
+        request.httpBody = httpBody
+        
+        URLSession.shared.dataTask(with: request) {(data, response, error) in
+            
+            
+            if let error = error {
+                print("Failed to get item info: \(error)")
+                return;
+            }
+            
+            if let response = response as? HTTPURLResponse {
+                
+                if(response.statusCode == 400){
+                    DispatchQueue.main.async {
+                        AlertDialog.alert(viewController:self, title:"入力エラー", message:"入力内容が間違っているよ。")
+                    }
+                    return
+                }else if(response.statusCode != 200){
+                    DispatchQueue.main.async {
+                        AlertDialog.alert(viewController:self, title:"予期せぬエラー", message:"問題が発生しちゃったよ。")
+                    }
+                    return
+                }
+                
+            }
+            
+            if let data = data {
+                do {
+                    let jsonDict = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+                    let success = jsonDict!["success"] as! Bool
+                    //let loginData = jsonDict!["data"] as! LoginData
+                    
+                    
+                    if(success) {
+                        let jsonData = try JSONSerialization.data(withJSONObject: jsonDict!["data"]!, options: .prettyPrinted)
+                        
+                        if let loginData = try? JSONDecoder().decode(LoginData.self, from: jsonData as Data) {
+                            print(loginData.email)
+                        }
+                    }
+                    
+                    DispatchQueue.main.async {
+                        //self.itemInfoTextView.text = message
+                        self.performSegue(withIdentifier: "goTabBar", sender: nil)
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        AlertDialog.alert(viewController:self, title:"予期せぬエラー", message:"問題が発生しちゃったよ。")
+                    }
+                    print("Error parsing the response.")
+                }
+            } else {
+                print("Unexpected error.")
+                DispatchQueue.main.async {
+                    AlertDialog.alert(viewController:self, title:"予期せぬエラー", message:"問題が発生しちゃったよ。")
+                }
+                return
+            }
+            
+        }.resume()
+        
+        //データ転送を管理するためのセッションを生成
+        //let session = URLSession(configuration: .default, delegate: nil, delegateQueue: OperationQueue.main)
+        //リクエストをタスクとして登録
+        //        let task = session.dataTask(with: request, completionHandler: (data, response, error), in
+        //
+        //        )
+        //        let task = session.dataTask(with: request, completionHandler: {
+        //            (data , response , error) in
+        //            // セッションを終了
+        //            session.finishTasksAndInvalidate()
+        //            // do try catch エラーハンドリング
+        //            do {
+        //                // JSONDecoderのインスタンス取得
+        //                let decoder = JSONDecoder()
+        //                // 受け取ったJSONデータをパース（解析）して格納
+        //                //let json = try decoder.decode(Response.self, from: data!)
+        //
+        //
+        //
+        //            } catch {
+        //                // エラー処理
+        //                 print("エラーが出ました")
+        //            }
+        //        })
+        //        // ダウンロード開始
+        //        task.resume()
     }
     
-    //メソッドの中でやる処理は１つが良い
-    //メソッドにわけよう
-    private func uiTextFieldRound(){
-        
+    //Modelの使い方わからず
+//    struct Response: Codable {
+//        let succcess: Bool
+//        let code: Int
+//        let data: LoginData
+//    }
+//
+//    struct ErrorResoinse: Codable {
+//        let succcess: Bool
+//        let code: Int
+//        let message: String
+//    }
+    
+    struct LoginData: Codable {
+        let name: String
+        let email: String
+        let token: String
     }
-    
-    
-    
     
     
 }


### PR DESCRIPTION
## やったこと
* ログイン画面のAPIの実装
* 取得したユーザー情報をUserDefaultsを使ってローカルに保存
## できるようになること（ユーザ目線）
* ログインできる
## 動作確認
* 実機とシミュレーターで大きなレイアウト崩れがないことは確認
* 未入力の項目があるとエラーダイアログが出ることを確認
* 誤ったアドレスやパスワードを入力するとエラーダイアログが出ることを確認
* 正しいアドレスとパスワードでログインできることを確認
## ハマりかけたところ
* メインスレッド以外でダイアログの処理を書いたところエラーになった（https://qiita.com/rymiyamoto/items/7ace750172b84a2ff809）
## ググっても理解が追いつかなかったところ/疑問点/今後の展望
* Modelをどう使うのか
* コードを書くべき場所、コードを分けた場合の非同期処理？の対処法
* Loadingの表示（まだ調べられていない）