### PR TITLE
アカウント登録のAPI処理を実装しました

### DIFF
--- a/KrononIosNakane/AlertDialog.swift
+++ b/KrononIosNakane/AlertDialog.swift
@@ -19,4 +19,22 @@ class AlertDialog{
         //実際に表示させる
         viewController.present(dialog, animated: true, completion: nil)
     }
+    
+    public static func createUserDialog(viewController:UIViewController, title:String, message:String){
+        //アラートのタイトル
+        let dialog = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        //ボタンのタイトル
+        //dialog.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        
+        let defaultAction: UIAlertAction = UIAlertAction(title: "OK", style: .default, handler:{
+            // ボタンが押された時の処理を書く（クロージャ実装）
+            (action: UIAlertAction!) -> Void in
+                viewController.performSegue(withIdentifier: "goTabBar", sender: nil)
+                print("OK")
+        })
+        dialog.addAction(defaultAction)
+        
+        //実際に表示させる
+        viewController.present(dialog, animated: true, completion: nil)
+    }
 }

--- a/KrononIosNakane/CreateAccountViewController.swift
+++ b/KrononIosNakane/CreateAccountViewController.swift
@@ -9,6 +9,24 @@ import UIKit
 
 class CreateAccountViewController: UIViewController, UITextFieldDelegate  {
     
+    @IBOutlet weak var inputName: MyTextField!
+    @IBOutlet weak var inputMail: MyTextField!
+    @IBOutlet weak var inputPassword1: MyTextField!
+    @IBOutlet weak var inputPassword2: MyTextField!
+    
+    @IBAction func createAccountAction(_ sender: Any) {
+        //入力チェック
+        if(!isCheckInput()){
+            return
+        }
+        //APIを叩く
+        createAccount(name: inputName.text!, email: inputMail.text!, password: inputPassword1.text!)
+    }
+    
+    @IBAction func loginAction(_ sender: Any) {
+        self.performSegue(withIdentifier: "goLoginView", sender: nil)
+    }
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,6 +41,17 @@ class CreateAccountViewController: UIViewController, UITextFieldDelegate  {
         //一部NavigationBarがすりガラス？のような感じになるのでfalseを指定
         self.navigationController?.navigationBar.isTranslucent = false
         
+        
+        setKeyboad()
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        self.parent?.navigationItem.hidesBackButton = false
+    }
+    
+    private func setKeyboad(){
         //キーボードのデフォルトを設定したいのに変わらないよ
         inputName.keyboardType = .default
         inputMail.keyboardType = .emailAddress
@@ -36,22 +65,7 @@ class CreateAccountViewController: UIViewController, UITextFieldDelegate  {
         inputMail.delegate = self
         inputPassword1.delegate = self
         inputPassword2.delegate = self
-        
-        
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        navigationController?.setNavigationBarHidden(false, animated: false)
-        self.parent?.navigationItem.hidesBackButton = false
-    }
-    
-//    override func viewDidAppear(_ animated: Bool) {
-//        //キーボードのデフォルトを設定したいのに変わらないよ
-//        inputName.keyboardType = .default
-//        inputMail.keyboardType = .emailAddress
-//        inputPassword1.keyboardType = .emailAddress
-//        inputPassword2.keyboardType = .emailAddress
-//    }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         //returnを押したらキーボードを閉じるように
@@ -59,28 +73,135 @@ class CreateAccountViewController: UIViewController, UITextFieldDelegate  {
         return true
     }
     
-    @IBOutlet weak var inputName: MyTextField!
-    @IBOutlet weak var inputMail: MyTextField!
-    @IBOutlet weak var inputPassword1: MyTextField!
-    @IBOutlet weak var inputPassword2: MyTextField!
-    
-    @IBAction func createAccountAction(_ sender: Any) {
-        self.performSegue(withIdentifier: "goTabBar", sender: nil)
+    private func isCheckInput()->Bool{
+        if(inputName.text!.isEmpty || inputMail.text!.isEmpty || inputPassword1.text!.isEmpty || inputPassword2.text!.isEmpty){
+            AlertDialog.alert(viewController:self, title:"入力エラー", message:"未入力の項目があるよ。")
+            return false
+        }
+        if(inputPassword1.text! != inputPassword2.text!){
+            AlertDialog.alert(viewController:self, title:"入力エラー", message:"パスワードが一致してないよ")
+            return false
+        }
+        
+        if(!isPasswordCheck(password: inputPassword1.text!)){
+            AlertDialog.alert(viewController:self, title:"入力エラー", message:"パスワードの入力規則を満たしていないよ。")
+            return false
+        }
+        return true
     }
     
-    @IBAction func loginAction(_ sender: Any) {
-        self.performSegue(withIdentifier: "goLoginView", sender: nil)
+    private func isPasswordCheck(password:String)->Bool{
+        var result = false
+        let pattern = NSPredicate(format: "SELF MATCHES %@", "^(?=.*[a-z])(?=.*[0-9])(?=.*[A-Z]).{8,20}$")
+        if(pattern.evaluate(with: password)){
+            result = true
+        }
+        return result
     }
     
     
-    /*
-     // MARK: - Navigation
-     
-     // In a storyboard-based application, you will often want to do a little preparation before navigation
-     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-     // Get the new view controller using segue.destination.
-     // Pass the selected object to the new view controller.
-     }
-     */
+    
+    private func createAccount(name:String, email:String, password:String){
+        guard let reqestUrl = URL(string: CommonData.IP_ADDRESS+"api/users") else{
+            return
+        }
+        
+        
+        let data: [String: Any] = ["name":name, "email": email, "password": password]
+        guard let httpBody = try? JSONSerialization.data(withJSONObject: data, options: []) else { return }
+        
+        //リクエストに必要な情報を生成
+        var request = URLRequest(url: reqestUrl)
+        request.httpMethod = "POST"
+        
+        request.setValue("Application/json", forHTTPHeaderField: "Content-Type")
+        //request.setValue("Basic \(authBase64)", forHTTPHeaderField: "Authorization")
+        request.httpBody = httpBody
+        
+        URLSession.shared.dataTask(with: request) {(data, response, error) in
+            
+            
+            if let error = error {
+                print("Failed to get item info: \(error)")
+                return;
+            }
+            
+            if let response = response as? HTTPURLResponse {
+                
+                if(response.statusCode == 400){
+                    DispatchQueue.main.async {
+                        AlertDialog.alert(viewController:self, title:"入力エラー", message:"メールアドレスが被っているよ")
+                    }
+                    return
+                }else if(response.statusCode != 201){
+                    DispatchQueue.main.async {
+                        AlertDialog.alert(viewController:self, title:"予期せぬエラー", message:"問題が発生しちゃったよ。")
+                    }
+                    return
+                }
+                
+            }
+            
+            if let data = data {
+                do {
+                    let jsonDict = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+                    let success = jsonDict!["success"] as! Bool
+                    //let loginData = jsonDict!["data"] as! LoginData
+                    
+                    
+                    if(success) {
+                        let jsonData = try JSONSerialization.data(withJSONObject: jsonDict!["data"]!, options: .prettyPrinted)
+                        
+                        if let createUserData = try? JSONDecoder().decode(CreateUserData.self, from: jsonData as Data) {
+                            UserDefaults.standard.set(createUserData.email, forKey:"email")
+                            UserDefaults.standard.set(createUserData.name, forKey:"name")
+                            UserDefaults.standard.set(createUserData.token, forKey:"token")
+                            //print(loginData.email)
+                        }
+                    }
+                    
+                    DispatchQueue.main.async {
+                        //self.itemInfoTextView.text = message
+                        //self.performSegue(withIdentifier: "goTabBar", sender: nil)
+                        AlertDialog.createUserDialog(viewController: self, title: "登録が完了したよ。", message: "")
+                    }
+                    
+                } catch {
+                    DispatchQueue.main.async {
+                        AlertDialog.alert(viewController:self, title:"予期せぬエラー", message:"問題が発生しちゃったよ。")
+                    }
+                    print("Error parsing the response.")
+                }
+            } else {
+                print("Unexpected error.")
+                DispatchQueue.main.async {
+                    AlertDialog.alert(viewController:self, title:"予期せぬエラー", message:"問題が発生しちゃったよ。")
+                }
+                return
+            }
+            
+        }.resume()
+        
+    }
+    
+    //Modelの使い方わからず
+    //    struct Response: Codable {
+    //        let succcess: Bool
+    //        let code: Int
+    //        let data: LoginData
+    //    }
+    //
+    //    struct ErrorResoinse: Codable {
+    //        let succcess: Bool
+    //        let code: Int
+    //        let message: String
+    //    }
+    
+    struct CreateUserData: Codable {
+        let name: String
+        let email: String
+        let token: String
+    }
+    
     
 }

--- a/KrononIosNakane/LoginViewController.swift
+++ b/KrononIosNakane/LoginViewController.swift
@@ -10,22 +10,6 @@ import UIKit
 
 class LoginViewController: UIViewController, UITextFieldDelegate {
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        //キーボードのデフォルトを設定したいのに変わらないよ
-        inputEmail.keyboardType = .emailAddress
-        inputPassword.keyboardType = .emailAddress
-        //入力内容を隠す
-        inputPassword.isSecureTextEntry = true
-        
-        inputEmail.delegate = self
-        inputPassword.delegate = self
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        navigationController?.setNavigationBarHidden(true, animated: false)
-    }
     
     @IBOutlet weak var inputEmail: UITextField!
     @IBOutlet weak var inputPassword: UITextField!
@@ -48,6 +32,25 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     }
     
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        //キーボードのデフォルトを設定したいのに変わらないよ
+        inputEmail.keyboardType = .emailAddress
+        inputPassword.keyboardType = .emailAddress
+        //入力内容を隠す
+        inputPassword.isSecureTextEntry = true
+        
+        inputEmail.delegate = self
+        inputPassword.delegate = self
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
+    
+    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         //returnを押したらキーボードを閉じるように
         textField.resignFirstResponder()
@@ -61,9 +64,6 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
             return
         }
         
-        let authString = String(format: "%@:%@", email, password)
-        let authData = authString.data(using: String.Encoding.utf8)!
-        let authBase64 = authData.base64EncodedString()
         
         let data: [String: Any] = ["email": email, "password": password]
         guard let httpBody = try? JSONSerialization.data(withJSONObject: data, options: []) else { return }
@@ -73,7 +73,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         request.httpMethod = "POST"
         
         request.setValue("Application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Basic \(authBase64)", forHTTPHeaderField: "Authorization")
+        //request.setValue("Basic \(authBase64)", forHTTPHeaderField: "Authorization")
         request.httpBody = httpBody
         
         URLSession.shared.dataTask(with: request) {(data, response, error) in


### PR DESCRIPTION
## やったこと
* アカウント作成画面のAPIの実装
* 登録したユーザー情報をUserDefaultsを使ってローカルに保存
## できるようになること（ユーザ目線）
* アカウント作成ができる
## 動作確認
* 実機とシミュレーターで大きなレイアウト崩れがないことは確認
* 未入力の項目があるとエラーダイアログが出ることを確認
* パスワードが一致しないとエラーダイアログが出ることを確認
* パスワードの入力規則を満たさないとエラーダイアログが出ることを確認
* 正しい入力内容でログインできることを確認
## ググっても理解が追いつかなかったところ/疑問点/今後の展望
* ダイアログのOKボタンを押した時の処理（画面遷移の処理）を記述したいときは、どこに書くべきか